### PR TITLE
Add g:nord_italic configuration option

### DIFF
--- a/lua/nordbuddy.lua
+++ b/lua/nordbuddy.lua
@@ -81,6 +81,10 @@ function M:use()
         uc = s.undercurl
     end
 
+    if vim.g.nord_italic ~= nil and not vim.g.nord_italic then
+        i = sno
+    end
+
     M.setup(self)
 
     for _, group in ipairs(M:colors()) do


### PR DESCRIPTION
The configuration option controls whether to use italic or not. A lot of
developers prefer not to use italics, so it'd be nice to have a switch
off.