### PR TITLE
Add lspsaga.nvim colors

### DIFF
--- a/lua/nordbuddy.lua
+++ b/lua/nordbuddy.lua
@@ -107,7 +107,8 @@ function M:colors()
         M:markdown(), --
         M:diff(), --
         M:telescope(), --
-        M:plugins() --
+        M:plugins(), --
+        M:lspsaga() --
     })
 end
 
@@ -504,6 +505,29 @@ function M:plugins()
         fugitive --
     })
 
+end
+
+function M:lspsaga()
+    return {
+        {'LspSagaDiagnosticBorder', c.nord12},
+        {'LspSagaDiagnosticHeader', c.nord12, cno, b},
+        {'LspSagaDiagnosticTruncateLine', c.nord12},
+        {'LspDiagnosticsFloatingWarn', c.nord12},
+        {'LspDiagnosticsFloatingInfor', c.nord10},
+        {'LspSagaShTruncateLine', c.nord1},
+        {'LspSagaDocTruncateLine', c.nord1},
+        {'LspSagaCodeActionTitle', c.nord12, cno, b},
+        {'LspSagaCodeActionTruncateLine', c.nord1},
+        {'LspSagaCodeActionContent', c.nord14, cno, b},
+        {'LspSagaRenamePromptPrefix', c.nord14},
+        {'LspSagaRenameBorder', c.nord7},
+        {'LspSagaHoverBorder', c.nord9},
+        {'LspSagaSignatureHelpBorder', c.nord14},
+        {'LspSagaLspFinderBorder', c.nord10},
+        {'LspSagaCodeActionBorder', c.nord8},
+        {'LspSagaAutoPreview', c.nord12},
+        {'LspSagaDefPreviewBorder', c.nord8}
+    }
 end
 
 return M


### PR DESCRIPTION
I use https://github.com/glepnir/lspsaga.nvim and it has it's own colors for certain popups that really sticks out when using a nord theme.

This commit changes the colors to the nearest available provided by this theme (except for the color in the provided screenshot. I took the liberty of making that an orange color instead of a purple one because of the context).

Example before:

![before](https://user-images.githubusercontent.com/161548/116168846-aaf73400-a703-11eb-94c5-368f0db74538.png)

And after:

![after](https://user-images.githubusercontent.com/161548/116168845-aa5e9d80-a703-11eb-98ab-0f22917e9b98.png)