### PR TITLE
Add symbols-outline.nvim colors

### DIFF
--- a/lua/nordbuddy.lua
+++ b/lua/nordbuddy.lua
@@ -112,6 +112,7 @@ function M:colors()
         M:neogit(), --
         M:telescope(), --
         M:whichkey(), --
+        M:symbolsoutline(), --
     })
 end
 
@@ -559,6 +560,13 @@ function M:whichkey()
         {'WhichKeyDesc', c.nord4}, --
         {'WhichKeyFloat', c.none, c.nord0:light(.05)}, --
         {'WhichKeyValue', c.nord4}, --
+    }
+end
+
+function M:symbolsoutline()
+    -- 'simrat39/symbols-outline.nvim'
+    return {
+        {'FocusedSymbol', c.nord13, cno, b}, --
     }
 end
 


### PR DESCRIPTION
Just a minor update to add custom [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim) colors.

Before:

![before](https://user-images.githubusercontent.com/161548/119911334-6e646580-bf59-11eb-8a85-edab7eef9df0.png)

After:

![after](https://user-images.githubusercontent.com/161548/119911337-6efcfc00-bf59-11eb-94cc-dd2e53222497.png)
