### PR TITLE
Updated packer instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plug 'maaslalani/nordbuddy'
 
 with `packer.nvim`
 ``` lua
-use {'maaslalani/nordbuddy', 'tjdevries/colorbuddy.nvim'}
+use {'maaslalani/nordbuddy', requires = {'tjdevries/colorbuddy.nvim'}}
 ```
 
 ### Setup


### PR DESCRIPTION
Since colorbuddy is a dependency this should be placed inside a "require" parameter for packer.nvim