### PR TITLE
Avoid using vimL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and [much more](https://github.com/maaslalani/nordbuddy/tree/main/lua/nordbuddy/
 
 ## Install
 
-You'll need (at least) Neovim 0.4.0 for `nordbuddy` to work. You'll also need [colorbuddy](https://github.com/tjdevries/colorbuddy.nvim).
+You'll need (at least) Neovim 0.5.0 for `nordbuddy` to work. You'll also need [colorbuddy](https://github.com/tjdevries/colorbuddy.nvim).
 
 with `Vim-Plug`
 ``` vim

--- a/colors/nordbuddy.lua
+++ b/colors/nordbuddy.lua
@@ -1,0 +1,2 @@
+local nordbuddy = require('nordbuddy')
+nordbuddy.use{}

--- a/colors/nordbuddy.vim
+++ b/colors/nordbuddy.vim
@@ -1,1 +1,0 @@
-lua require('nordbuddy').use{}


### PR DESCRIPTION
In nvim 0.5.0 is possible to use also lua files in colors folder. 
If backward compatibility is not a problem, I suggest to use only lua and avoid vimL.