### PR TITLE
No longer depends on colorbuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nordbuddy
 
-A [nord](https://www.nordtheme.com/)-esque colorscheme using [colorbuddy.nvim](https://github.com/tjdevries/colorbuddy.nvim)
+A [nord](https://www.nordtheme.com/)-esque colorscheme.
 
 Nordbuddy supports highlighting for [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter),
 [Neovim LSP](https://neovim.io/doc/user/lsp.html), [Telescope](https://github.com/nvim-telescope/telescope.nvim/),
@@ -11,20 +11,18 @@ and [much more](https://github.com/maaslalani/nordbuddy/tree/main/lua/nordbuddy/
 ## Requirements
 
 * Neovim 0.5+
-* [colorbuddy](https://github.com/tjdevries/colorbuddy.nvim)
 
 ## Install
 
 Using `packer.nvim`:
 
 ``` lua
-use { 'maaslalani/nordbuddy', requires = { 'tjdevries/colorbuddy.nvim' }}
+use { 'maaslalani/nordbuddy' }
 ```
 
 Or `vim-plug`:
 
 ``` vim
-Plug 'tjdevries/colorbuddy.nvim'
 Plug 'maaslalani/nordbuddy'
 ```
 
@@ -33,7 +31,7 @@ Plug 'maaslalani/nordbuddy'
 Enable the colorscheme in Lua (`init.lua`):
 
 ```lua
-require('colorbuddy').colorscheme('nordbuddy')
+vim.cmd('colorscheme nordbuddy')
 ```
 
 Or in Vimscript (`init.vim`):

--- a/lua/nordbuddy/colors/neogit.lua
+++ b/lua/nordbuddy/colors/neogit.lua
@@ -4,7 +4,7 @@ return function(c, s, cs)
         {'NeogitDiffAddHighlight', c.nord14, c.nord1},
         {'NeogitDiffDeleteHighlight', c.nord11, c.nord1},
         {'NeogitDiffContextHighlight', c.nord13, c.nord0},
-        {'NeogitHunkHeaderHighlight', c.nord3:light(), c.nord0},
-        {'NeogitHunkHeader', c.nord3:light(), c.nord0}
+        {'NeogitHunkHeaderHighlight', c.nord3_light, c.nord0},
+        {'NeogitHunkHeader', c.nord3_light, c.nord0}
     }
 end

--- a/lua/nordbuddy/colors/syntax.lua
+++ b/lua/nordbuddy/colors/syntax.lua
@@ -171,7 +171,7 @@ return function(c, s, cs)
     local groups = {
         {attributes, c.nord9},
         {numbers, c.nord15},
-        {comments, c.nord3:light(), c.none, cs.comments},
+        {comments, c.nord3_light, c.none, cs.comments},
         {constructors, c.nord4, c.none, cs.italic}, -- in C++ variable->constructors() \\ TS docs unclear
         {conditionals, c.nord10, c.none, cs.italic},
         {constants, c.nord4},

--- a/lua/nordbuddy/colors/whichkey.lua
+++ b/lua/nordbuddy/colors/whichkey.lua
@@ -3,9 +3,9 @@ return function(c, s, cs)
     return {
         {'WhichKey', c.nord8},
         {'WhichKeyGroup', c.nord9},
-        {'WhichKeySeparator', c.nord3:light()},
+        {'WhichKeySeparator', c.nord3_light},
         {'WhichKeyDesc', c.nord4},
-        {'WhichKeyFloat', c.none, c.nord0:light(.05)},
+        {'WhichKeyFloat', c.none, c.nord0_light},
         {'WhichKeyValue', c.nord4},
     }
 end

--- a/lua/nordbuddy/palette.lua
+++ b/lua/nordbuddy/palette.lua
@@ -1,10 +1,11 @@
 return {
     -- Polar Night
     [0] = '#2e3440', -- dark black: bg
+    ['0_light'] = '#3B414D',
     [1] = '#3b4252', -- black
     [2] = '#434c5e', -- bright black
     [3] = '#4c566a', -- gray
-    -- ['3_bright'] = '#616e88'
+    ['3_light'] = '#667084',
 
     -- Snow Storm
     [4] = '#d8dee9', -- dark white: fg

--- a/lua/nordbuddy/utils.lua
+++ b/lua/nordbuddy/utils.lua
@@ -24,4 +24,12 @@ function utils:highlight_to_groups(highlight)
     end
 end
 
+function utils:highlight(n, fg, bg, font)
+    vim.highlight.create(n, {
+        guibg = bg and bg or 'NONE',
+        guifg = fg and fg or 'NONE',
+        gui = font and font or 'NONE',
+    })
+end
+
 return utils


### PR DESCRIPTION
This PR improves startup time significantly by removing the dependence on colorbuddy.

```
035.762  001.940  001.940: sourcing /home/anders/.local/share/nvim/site/pack/packer/start/nordbuddy/colors/nordbuddy.lua
```

vs ~20ms.

Closes #24