### PR TITLE
Minor refactoring of certain areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and [much more](https://github.com/maaslalani/nordbuddy/tree/main/lua/nordbuddy/
 
 ## Usage
 
-This colorscheme can be install, configure and enable through `packer.nvim`. 
+This colorscheme can be installed, configured and enabled through `packer.nvim`:
 
 ``` lua
 use {
@@ -65,7 +65,7 @@ Plug 'maaslalani/nordbuddy'
 Configure and enable the colorscheme in `init.lua` with:
 
 ``` lua
-require('nordbuddy'):colorscheme({
+require('nordbuddy').colorscheme({
     underline_option = 'none',
     italic = true,
     italic_comments = false,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This colorscheme can be install, configure and enable through `packer.nvim`.
 use {
     'maaslalani/nordbuddy',
     config = function()
-        require('nordbuddy'):colorscheme(
+        require('nordbuddy').colorscheme(
         -- This function takes a table as argument.
         -- If an empty table is passed, these values are implicitly assigned.
         {

--- a/lua/nordbuddy/colors/diff.lua
+++ b/lua/nordbuddy/colors/diff.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     return {
         {'DiffAdd', c.nord14, c.nord1},
         {'DiffChange', c.nord13, c.nord1},

--- a/lua/nordbuddy/colors/fugitive.lua
+++ b/lua/nordbuddy/colors/fugitive.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- tpope/vim-fugitive
     return {
         {'gitcommitDiscardedFile', c.nord11},

--- a/lua/nordbuddy/colors/gitgutter.lua
+++ b/lua/nordbuddy/colors/gitgutter.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- 'airblade/vim-gitgutter'
     return {
         {'GitGutterAdd', c.nord14, c.nord1},

--- a/lua/nordbuddy/colors/gitsigns.lua
+++ b/lua/nordbuddy/colors/gitsigns.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- 'lewis6991/gitsigns.nvim'
     return {
         {'GitSignsAdd', c.nord14, c.nord0},

--- a/lua/nordbuddy/colors/indent_blankline.lua
+++ b/lua/nordbuddy/colors/indent_blankline.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- lukas-reineke/indent-blankline.nvim
     return {
         {'IndentBlanklineChar', c.nord3},

--- a/lua/nordbuddy/colors/init.lua
+++ b/lua/nordbuddy/colors/init.lua
@@ -19,4 +19,4 @@ local colors = {
     'whichkey'
 }
 
-return utils:prepare(colors)
+return utils.prepare(colors)

--- a/lua/nordbuddy/colors/lsp.lua
+++ b/lua/nordbuddy/colors/lsp.lua
@@ -1,5 +1,4 @@
- return function(opts)
-    local c = opts.c
+ return function(c)
     return {
         {'LspReferenceText', c.nord4},
         {'LspReferenceRead', c.nord5},

--- a/lua/nordbuddy/colors/lspsaga.lua
+++ b/lua/nordbuddy/colors/lspsaga.lua
@@ -1,5 +1,4 @@
- return function(opts)
-    local c, s = opts.c, opts.s
+ return function(c, s)
     -- 'glepnir/lspsaga.nvim'
     return {
         {'LspSagaDiagnosticBorder', c.nord12},

--- a/lua/nordbuddy/colors/markdown.lua
+++ b/lua/nordbuddy/colors/markdown.lua
@@ -1,7 +1,6 @@
 local utils = require('nordbuddy.utils')
 
- return function(opts)
-    local c, s = opts.c, opts.s
+ return function(c, s)
     local to_groups = utils:highlight_to_groups({c.nord8, c.none})
     local delimiters = to_groups({
         'markdownH1Delimiter',

--- a/lua/nordbuddy/colors/markdown.lua
+++ b/lua/nordbuddy/colors/markdown.lua
@@ -1,7 +1,7 @@
 local utils = require('nordbuddy.utils')
 
  return function(c, s)
-    local to_groups = utils:highlight_to_groups({c.nord8, c.none})
+    local to_groups = utils.highlight_to_groups({c.nord8, c.none})
     local delimiters = to_groups({
         'markdownH1Delimiter',
         'markdownH2Delimiter',
@@ -11,7 +11,7 @@ local utils = require('nordbuddy.utils')
         'markdownH6Delimiter'
     })
 
-    to_groups = utils:highlight_to_groups({c.nord8, c.none, s.bold})
+    to_groups = utils.highlight_to_groups({c.nord8, c.none, s.bold})
     local headers = to_groups({
         'markdownH1',
         'markdownH2',
@@ -21,7 +21,7 @@ local utils = require('nordbuddy.utils')
         'markdownH6'
     })
 
-    return utils:merge({
+    return utils.merge({
         delimiters,
         headers,
         {

--- a/lua/nordbuddy/colors/neogit.lua
+++ b/lua/nordbuddy/colors/neogit.lua
@@ -1,5 +1,4 @@
- return function(opts)
-    local c = opts.c
+ return function(c)
     -- 'TimUntersberger/neogit'
     return {
         {'NeogitDiffAddHighlight', c.nord14, c.nord1},

--- a/lua/nordbuddy/colors/neorg.lua
+++ b/lua/nordbuddy/colors/neorg.lua
@@ -1,5 +1,4 @@
- return function(opts)
-    local c = opts.c
+ return function(c)
     -- 'vhyrro/neorg'
     return {
         {'Conceal', c.none},

--- a/lua/nordbuddy/colors/standard.lua
+++ b/lua/nordbuddy/colors/standard.lua
@@ -1,7 +1,8 @@
 local utils = require('nordbuddy.utils')
 
 return function(c, s, cs, opts)
-    local options = nil
+    local options
+
     if opts.minimal_mode then
         options = {
             --- Editor---

--- a/lua/nordbuddy/colors/standard.lua
+++ b/lua/nordbuddy/colors/standard.lua
@@ -1,11 +1,8 @@
 local utils = require('nordbuddy.utils')
 
-return function(opts)
-    local c, s, cs = opts.c, opts.s, opts.cs
-    local minimal_mode = opts.minimal_mode
-
+return function(c, s, cs, opts)
     local options = nil
-    if minimal_mode then
+    if opts.minimal_mode then
         options = {
             --- Editor---
             {'CursorLine', c.none, c.nord0_light},

--- a/lua/nordbuddy/colors/standard.lua
+++ b/lua/nordbuddy/colors/standard.lua
@@ -93,7 +93,7 @@ return function(c, s, cs, opts)
         {'Whitespace', c.nord4} -- idk
     }
 
-    return utils:merge({
+    return utils.merge({
         options,
         defaults
     })

--- a/lua/nordbuddy/colors/symbols_outline.lua
+++ b/lua/nordbuddy/colors/symbols_outline.lua
@@ -1,5 +1,4 @@
- return function(opts)
-    local c, s = opts.c, opts.s
+ return function(c, s)
     -- 'simrat39/symbols-outline.nvim'
     return {
         {'FocusedSymbol', c.nord13, c.none, s.bold},

--- a/lua/nordbuddy/colors/syntax.lua
+++ b/lua/nordbuddy/colors/syntax.lua
@@ -1,7 +1,6 @@
 local utils = require('nordbuddy.utils')
 
-return function(opts)
-    local c, s, cs = opts.c, opts.s, opts.cs
+return function(c, s, cs)
     local attributes = {
         'TSAnnotation', 'TSAttribute', -- TS
         'luametatableevents', 'luametatablearithmetic',

--- a/lua/nordbuddy/colors/syntax.lua
+++ b/lua/nordbuddy/colors/syntax.lua
@@ -208,9 +208,9 @@ return function(c, s, cs)
 
     -- Apply grouping to each color group
     for _, group in ipairs(groups) do
-        highlights = utils:merge({
+        highlights = utils.merge({
             highlights,
-            utils:highlight_to_groups({group[2], group[3], group[4]})(group[1])
+            utils.highlight_to_groups({group[2], group[3], group[4]})(group[1])
         })
     end
 

--- a/lua/nordbuddy/colors/telescope.lua
+++ b/lua/nordbuddy/colors/telescope.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c, s = opts.c, opts.s
+return function(c, s)
     -- 'nvim-telescope/telescope.nvim'
     return {
         {'TelescopeBorder', c.nord3},

--- a/lua/nordbuddy/colors/vimwiki.lua
+++ b/lua/nordbuddy/colors/vimwiki.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- 'vimwiki/vimwiki'
     return {
         {'VimwikiHeader1', c.nord8},

--- a/lua/nordbuddy/colors/whichkey.lua
+++ b/lua/nordbuddy/colors/whichkey.lua
@@ -1,5 +1,4 @@
-return function(opts)
-    local c = opts.c
+return function(c)
     -- 'folke/whick-key-nvim'
     return {
         {'WhichKey', c.nord8},

--- a/lua/nordbuddy/init.lua
+++ b/lua/nordbuddy/init.lua
@@ -62,12 +62,7 @@ local function initialize(opts)
     local c = create_colors()
     local s = create_styles()
     local cs = create_custom_styles(s, opts)
-    local groups = load_groups({
-        c = c,
-        s = s,
-        cs = cs,
-        minimal_mode = opts.minimal_mode
-    })
+    local groups = load_groups(c, s, cs, opts)
 
     for _, group in ipairs(groups) do utils:highlight(unpack(group)) end
 end

--- a/lua/nordbuddy/init.lua
+++ b/lua/nordbuddy/init.lua
@@ -4,6 +4,25 @@ local all_colors = require('nordbuddy.colors')
 local vim = vim
 local M = {}
 
+local default_opts = {
+    underline_option = 'none',
+    italic = true,
+    italic_comments = false,
+    minimal_mode = false
+}
+
+local function create_options(config)
+    local user_opts = {}
+    local global_opts = {}
+
+    for k in pairs(default_opts) do
+        user_opts[k] = config[k]
+        global_opts[k] = vim.g['nord_' ..  k]
+    end
+
+    return vim.tbl_extend('force', default_opts, global_opts, user_opts)
+end
+
 local function create_colors()
     local c = {}
     for k, v in pairs(palette) do
@@ -26,40 +45,22 @@ local function create_styles()
     return s
 end
 
-local function create_custom_styles(s, opts)
-    local default_opts = {
-        underline_option = 'none',
-        italic = true,
-        italic_comments = false,
-        minimal_mode = false
-    }
-
-    for k, v in pairs(default_opts) do
-        if opts[k] ~= nil and opts[k] ~= v then
-            default_opts[k] = opts[k]
-        end
-
-        local g_opt = vim.g['nord_' .. k]
-        if g_opt ~= nil and g_opt ~= v then
-            default_opts[k] = g_opt
-        end
-    end
-
+local function create_custom_styles(s, options)
     local underline = s.none
     local italic = s.italic
     local comments = s.none
 
-    if default_opts.underline_option == 'underline' then
+    if options.underline_option == 'underline' then
         underline = s.underline
-    elseif default_opts.underline_option == 'undercurl' then
+    elseif options.underline_option == 'undercurl' then
         underline = s.undercurl
     end
 
-    if not default_opts.italic then
+    if not options.italic then
         italic = s.none
     end
 
-    if default_opts.italic_comments then
+    if options.italic_comments then
         comments = s.italic
     end
 
@@ -75,18 +76,19 @@ local function load_groups(...)
     return utils.merge(definitions)
 end
 
-local function initialize(opts)
+local function initialize(config)
+    local options = create_options(config)
     local c = create_colors()
     local s = create_styles()
-    local cs = create_custom_styles(s, opts)
-    local groups = load_groups(c, s, cs, opts)
+    local cs = create_custom_styles(s, options)
+    local groups = load_groups(c, s, cs, options)
 
     for _, group in ipairs(groups) do
         utils.highlight(unpack(group))
     end
 end
 
-function M.colorscheme(opts)
+function M.colorscheme(config)
     vim.g.colors_name = 'nordbuddy'
     vim.g.terminal_color_0 = palette[1]
     vim.g.terminal_color_1 = palette[11]
@@ -105,7 +107,7 @@ function M.colorscheme(opts)
     vim.g.terminal_color_14 = palette[7]
     vim.g.terminal_color_15 = palette[6]
 
-    initialize(opts)
+    initialize(config)
 end
 
 return M

--- a/lua/nordbuddy/init.lua
+++ b/lua/nordbuddy/init.lua
@@ -67,7 +67,7 @@ local function initialize(opts)
     for _, group in ipairs(groups) do utils.highlight(unpack(group)) end
 end
 
-function M:colorscheme(opts)
+function M.colorscheme(opts)
     vim.g.colors_name = 'nordbuddy'
     vim.g.terminal_color_0 = palette[1]
     vim.g.terminal_color_1 = palette[11]

--- a/lua/nordbuddy/init.lua
+++ b/lua/nordbuddy/init.lua
@@ -6,7 +6,9 @@ local M = {}
 
 local function create_colors()
     local c = {}
-    for k, v in pairs(palette) do c['nord' .. k] = v end
+    for k, v in pairs(palette) do
+        c['nord' .. k] = v
+    end
     return c
 end
 
@@ -16,7 +18,11 @@ local function create_styles()
         'bold', 'underline', 'undercurl', 'strikethrough', 'reverse', 'inverse',
         'italic', 'standout', 'nocombine'
     }
-    for _, v in pairs(names) do s[v] = v end
+
+    for _, v in pairs(names) do
+        s[v] = v
+    end
+
     return s
 end
 
@@ -27,11 +33,16 @@ local function create_custom_styles(s, opts)
         italic_comments = false,
         minimal_mode = false
     }
+
     for k, v in pairs(default_opts) do
-        if opts[k] ~= nil and opts[k] ~= v then default_opts[k] = opts[k] end
+        if opts[k] ~= nil and opts[k] ~= v then
+            default_opts[k] = opts[k]
+        end
 
         local g_opt = vim.g['nord_' .. k]
-        if g_opt ~= nil and g_opt ~= v then default_opts[k] = g_opt end
+        if g_opt ~= nil and g_opt ~= v then
+            default_opts[k] = g_opt
+        end
     end
 
     local underline = s.none
@@ -44,16 +55,22 @@ local function create_custom_styles(s, opts)
         underline = s.undercurl
     end
 
-    if not default_opts.italic then italic = s.none end
+    if not default_opts.italic then
+        italic = s.none
+    end
 
-    if default_opts.italic_comments then comments = s.italic end
+    if default_opts.italic_comments then
+        comments = s.italic
+    end
 
     return {italic = italic, underline = underline, comments = comments}
 end
 
 local function load_groups(...)
     local definitions = {}
-    for _, fn in pairs(all_colors) do table.insert(definitions, fn(...)) end
+    for _, fn in pairs(all_colors) do
+        table.insert(definitions, fn(...))
+    end
 
     return utils.merge(definitions)
 end
@@ -64,7 +81,9 @@ local function initialize(opts)
     local cs = create_custom_styles(s, opts)
     local groups = load_groups(c, s, cs, opts)
 
-    for _, group in ipairs(groups) do utils.highlight(unpack(group)) end
+    for _, group in ipairs(groups) do
+        utils.highlight(unpack(group))
+    end
 end
 
 function M.colorscheme(opts)

--- a/lua/nordbuddy/init.lua
+++ b/lua/nordbuddy/init.lua
@@ -55,7 +55,7 @@ local function load_groups(...)
     local definitions = {}
     for _, fn in pairs(all_colors) do table.insert(definitions, fn(...)) end
 
-    return utils:merge(definitions)
+    return utils.merge(definitions)
 end
 
 local function initialize(opts)
@@ -64,7 +64,7 @@ local function initialize(opts)
     local cs = create_custom_styles(s, opts)
     local groups = load_groups(c, s, cs, opts)
 
-    for _, group in ipairs(groups) do utils:highlight(unpack(group)) end
+    for _, group in ipairs(groups) do utils.highlight(unpack(group)) end
 end
 
 function M:colorscheme(opts)

--- a/lua/nordbuddy/utils.lua
+++ b/lua/nordbuddy/utils.lua
@@ -1,6 +1,6 @@
 local utils = {}
 
-function utils:prepare(modules)
+function utils.prepare(modules)
     local prepared_modules = {}
     for _, v in ipairs(modules) do
         table.insert(prepared_modules, require('nordbuddy.colors.' .. v))
@@ -8,13 +8,13 @@ function utils:prepare(modules)
     return prepared_modules
 end
 
-function utils:merge(list)
+function utils.merge(list)
     local acc = {}
     for _, result in ipairs(list) do vim.list_extend(acc, result) end
     return acc
 end
 
-function utils:highlight_to_groups(highlight)
+function utils.highlight_to_groups(highlight)
     return function(groups)
         local acc = {}
         for _, name in ipairs(groups) do
@@ -24,7 +24,7 @@ function utils:highlight_to_groups(highlight)
     end
 end
 
-function utils:highlight(n, fg, bg, font)
+function utils.highlight(n, fg, bg, font)
     vim.highlight.create(n, {
         guibg = bg and bg or 'NONE',
         guifg = fg and fg or 'NONE',

--- a/lua/nordbuddy/utils.lua
+++ b/lua/nordbuddy/utils.lua
@@ -10,7 +10,9 @@ end
 
 function utils.merge(list)
     local acc = {}
-    for _, result in ipairs(list) do vim.list_extend(acc, result) end
+    for _, result in ipairs(list) do
+        vim.list_extend(acc, result)
+    end
     return acc
 end
 


### PR DESCRIPTION
This PR introduces the following changes and the reasoning behind them:

## Revert back to argument list for color module functions

3dcd4504957daa4a8a7d05e9280aea2235cabc13 changed the signatures of the color modules. This introduced unpacking of the arguments, which I don't see any advantage over vs just appending an argument, because the latter would not have required changing any of these modules except for the ones that needed the new options.

## Use dot notation vs colon on modules

The colon notation (introduced at ff1e8be5b474c5e9e52e2889c85f633f2aba06d5) is actually used for instance members, like when you create a new "class" instance in Lua. If you use the colon notation and run it through a linter you'll immediately see this because it will complaint that the first argument is not "self", which it would be in an instance.

**This unfortunately breaks users configs**...but at least the commit is prefixed so that it's easy to catch on update.

## Don't collapse certain statements

I find it really hard to read Lua code when if- and for- statements are collapsed. This feels very unnatural in Lua as well with the exception of where you wanna do a Ternary.

## Updated configuration implementation

The configuration implementation has been changed so that it does not mutate the default configuration object. Also, instead of passing around a partial `opts` table around in the codebase, this is now a complete one that constructed in this priority:

* defaults
* globals (`g`'s)
* user (i.e. via `.colorscheme()`)

## Updated README

Just some wording stuff.