### PR TITLE
Added lualine-lsp-progress color configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,8 @@ let g:nord_italic_comments = v:false
 let g:nord_minimal_mode = v:false
 colorscheme nordbuddy
 ```
+
+## Notes
+
+Some plugin highlights are configured manually with Lua tables. This colorscheme comes with some
+[pre-made configurations](https://github.com/maaslalani/nordbuddy/tree/main/lua/nordbuddy/configs) that contains setup instructions.

--- a/lua/nordbuddy/configs/lualine_lsp_progress.lua
+++ b/lua/nordbuddy/configs/lualine_lsp_progress.lua
@@ -1,0 +1,23 @@
+local palette = require('nordbuddy.palette')
+
+-- arkav/lualine-lsp-progress
+-- usage:
+--     require'lualine'.setup{
+--         -- ...
+--         sections = {
+--             lualine_c = {
+--                 ...,
+--                 { 'lsp_progress',
+--                     colors = require('nordbuddy.configs.lualine_lsp_progress')
+--                 }
+--             }
+--         }
+--     }
+
+return {
+  percentage = palette.white,
+  title = palette.white,
+  message = palette.white,
+  spinner = palette.white,
+  lsp_client_name = palette.bright_cyan,
+}


### PR DESCRIPTION
Some plugins don't have standard highlight definitions by design, and instead relies on configuration via Lua tables.

This is an example of such a case. Kind of a shame, because this requires additional documentation. And speaking of which, how should this be tackled in the README ?