### PR TITLE
Add nvim-tree colors

### DIFF
--- a/lua/nordbuddy/colors/init.lua
+++ b/lua/nordbuddy/colors/init.lua
@@ -16,7 +16,8 @@ local colors = {
     'syntax',
     'telescope',
     'vimwiki',
-    'whichkey'
+    'whichkey',
+    'nvim_tree',
 }
 
 return vim.tbl_map(function (v)

--- a/lua/nordbuddy/colors/nvim_tree.lua
+++ b/lua/nordbuddy/colors/nvim_tree.lua
@@ -1,0 +1,18 @@
+-- 'kyazdani42/nvim-tree.lua'
+return function(c, s)
+    return {
+        {'NvimTreeSymlink', c.purple, c.none, s.bold },
+        {'NvimTreeFolderIcon', c.blue, c.none, s.bold },
+        {'NvimTreeRootFolder', c.purple, c.none, s.none },
+        {'NvimTreeExecFile', c.green, c.none, s.bold },
+        {'NvimTreeSpecialFile', c.yellow, c.none, s.bold },
+        {'NvimTreeImageFile', c.purple, c.none, s.bold },
+        {'NvimTreeOpenedFile', c.green, c.none, s.bold },
+        {'NvimTreeGitDirty', c.red, c.none, s.none },
+        {'NvimTreeGitDeleted', c.red, c.none, s.none },
+        {'NvimTreeStaged', c.green, c.none, s.none },
+        {'NvimTreeMerge', c.orange, c.none, s.none },
+        {'NvimTreeRenamed', c.purple, c.none, s.none },
+        {'NvimTreeNew', c.yellow, c.none, s.none },
+    }
+end


### PR DESCRIPTION
Adds custom colors for https://github.com/kyazdani42/nvim-tree.lua

The default ones this plugin uses looks really harsh in a cool nord landscape :slightly_smiling_face: 

---

Before:

![before](https://user-images.githubusercontent.com/161548/142930307-9c40ba74-4f56-4af4-99d1-36615970220b.png)

After:

![after](https://user-images.githubusercontent.com/161548/142930317-7eab755b-16e5-4bdf-bdb1-662fc59ceebd.png)
