### PR TITLE
Add nvim-cmp completion kind colors

### DIFF
--- a/lua/nordbuddy/colors/cmp.lua
+++ b/lua/nordbuddy/colors/cmp.lua
@@ -1,12 +1,19 @@
 -- 'hrsh7th/nvim-cmp'
 return function(c)
   return {
-    {'CmpDocumentation', c.white, c.none },
-    {'CmpDocumentationBorder', c.grayish, c.none },
-    {'CmpItemAbbr', c.dark_white, c.none },
-    {'CmpItemAbbrMatch', c.bright_cyan, c.none },
-    {'CmpItemAbbrMatchFuzzy', c.bright_cyan, c.none },
-    {'CmpItemKind', c.grayish, c.none },
-    {'CmpItemMenu', c.none, c.black }
+    {'CmpDocumentation', c.white, c.none},
+    {'CmpDocumentationBorder', c.grayish, c.none},
+    {'CmpItemAbbr', c.dark_white, c.none},
+    {'CmpItemAbbrMatch', c.bright_cyan, c.none},
+    {'CmpItemAbbrMatchFuzzy', c.bright_cyan, c.none},
+    {'CmpItemKind', c.grayish, c.none},
+    {'CmpItemMenu', c.none, c.black},
+    {'CmpItemKindDefault', c.yellow, c.none},
+    {'CmpItemAbbrMatch', c.blue, c.none},
+    {'CmpItemAbbrMatchFuzzy', c.blue, c.none},
+    {'CmpItemKindFunction', c.purple, c.none},
+    {'CmpItemKindMethod', c.purple, c.none},
+    {'CmpItemKindVariable', c.cyan, c.none},
+    {'CmpItemKindKeyword', c.white, c.none},
   }
 end


### PR DESCRIPTION
Completion kind colors landed recently in cmp, so I thought I'd add support for this.

Ref: https://github.com/hrsh7th/nvim-cmp/pull/584

Before:
![before](https://user-images.githubusercontent.com/161548/143788367-39819b8f-29ec-44dc-a5d0-99d5303da63e.png)

After:
![after](https://user-images.githubusercontent.com/161548/143788368-bb4d12b6-97f2-4bc2-8279-6139a329c9a3.png)
