### PR TITLE
Add support for lightspeed.nvim

### DIFF
--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -6,6 +6,7 @@ local colors = {
     'gitsigns',
     'hop',
     'indent_blankline',
+    'lightspeed',
     'lsp',
     'lspsaga',
     'markdown',

--- a/lua/nordic/colors/lightspeed.lua
+++ b/lua/nordic/colors/lightspeed.lua
@@ -1,0 +1,15 @@
+-- 'ggandor/lightspeed.nvim'
+return function(c, s)
+    return {
+        { 'LightspeedLabel', c.blue, c.none, s.bold },
+        { 'LightspeedLabelOverlapped', c.blue, c.dark_white, s.reverse },
+        { 'LightspeedLabelDistant', c.purple, c.none, s.bold },
+        { 'LightspeedLabelDistantOverlapped', c.purple, c.none, s.reverse },
+        { 'LightspeedShortcut', c.intense_blue, c.black, s.bold },
+        { 'LightspeedShortcutOverlapped', c.intense_blue, c.none, s.reverse },
+        { 'LightspeedMaskedChar', c.dark_white, c.bright_black, s.bold },
+        { 'LightspeedGreyWash', c.grayish },
+        { 'LightspeedUnlabeledMatch', c.bright_white, c.bright_black },
+        { 'LightspeedOneCharMatch', c.cyan, c.none, s.reverse },
+    }
+end


### PR DESCRIPTION
This commit adds support for https://github.com/ggandor/lightspeed.nvim

<img width="709" alt="CleanShot 2021-12-10 at 23 57 08@2x" src="https://user-images.githubusercontent.com/831613/145640398-e0da0368-a22e-44d7-9047-0258befc4c39.png">