### PR TITLE
Improve contrast and intensity of lightspeed.nvim colors

### DIFF
--- a/lua/nordic/colors/lightspeed.lua
+++ b/lua/nordic/colors/lightspeed.lua
@@ -1,12 +1,12 @@
 -- 'ggandor/lightspeed.nvim'
 return function(c, s)
     return {
-        { 'LightspeedLabel', c.blue, c.none, s.bold },
-        { 'LightspeedLabelOverlapped', c.blue, c.dark_white, s.reverse },
-        { 'LightspeedLabelDistant', c.purple, c.none, s.bold },
-        { 'LightspeedLabelDistantOverlapped', c.purple, c.none, s.reverse },
-        { 'LightspeedShortcut', c.intense_blue, c.black, s.bold },
-        { 'LightspeedShortcutOverlapped', c.intense_blue, c.none, s.reverse },
+        { 'LightspeedLabel', c.yellow, c.none },
+        { 'LightspeedLabelOverlapped', c.yellow, c.black, s.reverse },
+        { 'LightspeedLabelDistant', c.purple, c.bright_black, s.bold },
+        { 'LightspeedLabelDistantOverlapped', c.purple, c.bright_black, s.reverse },
+        { 'LightspeedShortcut', c.orange, c.none, s.bold },
+        { 'LightspeedShortcutOverlapped', c.orange, c.black, s.reverse },
         { 'LightspeedMaskedChar', c.dark_white, c.bright_black, s.bold },
         { 'LightspeedGreyWash', c.grayish },
         { 'LightspeedUnlabeledMatch', c.bright_white, c.bright_black },


### PR DESCRIPTION
This commit amends https://github.com/andersevenrud/nordic.nvim/pull/53 with more contrast and intense coloring for match groups.

Before:
<img width="685" alt="CleanShot 2021-12-11 at 10 09 26@2x" src="https://user-images.githubusercontent.com/831613/145667929-b1c9bc98-8b51-427d-9ff1-4ba1834c8216.png">
<img width="683" alt="CleanShot 2021-12-11 at 10 09 44@2x" src="https://user-images.githubusercontent.com/831613/145667938-56b38724-0a14-4aee-b276-ece439fc74a8.png">

After:
<img width="673" alt="CleanShot 2021-12-11 at 10 08 26@2x" src="https://user-images.githubusercontent.com/831613/145667894-61f694e3-f229-4e42-8649-75516af5a55d.png">
<img width="582" alt="CleanShot 2021-12-11 at 10 08 54@2x" src="https://user-images.githubusercontent.com/831613/145667913-5d417296-d1c3-4447-9622-c06853ec896c.png">

