### PR TITLE
Adjust treesitter text highlights

### DIFF
--- a/lua/nordic/colors/syntax.lua
+++ b/lua/nordic/colors/syntax.lua
@@ -191,14 +191,7 @@ return function(c, s, cs)
         'rustCommentBlockDoc',
     }
     local texts = {
-        -- TS
-        'TSText',
-        'TSStrong',
-        'TSEmphais',
-        'TSUnderline',
-        'TSStrike',
-        'TSTitle',
-        'TSLiteral',
+        'TSText', -- TS
         'Text', -- VL
         'manTitle', -- man
     }
@@ -302,5 +295,13 @@ return function(c, s, cs)
         { warnings, c.yellow },
         { dangers, c.yellow },
         { errors, c.red },
+
+        { 'TSTitle', c.bright_cyan },
+        { 'TSStrong', c.dark_white, c.none, s.bold },
+        { { 'TSEmphasis', 'TSTextReference' }, c.dark_white, c.none, s.italic },
+        { 'TSUnderline', c.dark_white, c.none, s.underline },
+        { 'TSStrike', c.dark_white, c.none, s.strikethrough },
+        { 'TSLiteral', c.cyan },
+        { 'TSStringEscape', c.grayish },
     }
 end


### PR DESCRIPTION
Stylize certain treesitter highlights to improve visibility in formatted
text documents, like Markdown.

---

Just saw that the Markdown treesitter parser was merged into nvim-treesitter, and tried it out. All of the sudden my files looked really flat :sweat_smile: 

I'll have to look at some other filetypes that uses these same treesitter highlights to make sure nothing was really messed up... but I'm fairly confident.

Before:

![before2](https://user-images.githubusercontent.com/161548/146075294-11577614-b21b-4c7c-bbf0-e10d2c4d3c8e.png)

After:

![after2](https://user-images.githubusercontent.com/161548/146075310-4293fab0-21ce-412c-b1e6-c76f7b4afb3f.png)

