### PR TITLE
Add support for Packer

### DIFF
--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -20,6 +20,7 @@ local colors = {
     'vimwiki',
     'whichkey',
     'nvim_tree',
+    'packer',
 }
 
 return function()

--- a/lua/nordic/colors/packer.lua
+++ b/lua/nordic/colors/packer.lua
@@ -1,0 +1,7 @@
+-- 'wbthomason/packer.nvim'
+return function(c)
+    return {
+        { 'packerHash', c.grayish, c.none },
+        { 'packerStatusSuccess', c.green, c.none },
+    }
+end


### PR DESCRIPTION
Added couple of colours for Packer which should make it easier to read change logs.

Before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/69750637/146467401-477b6c3e-acad-4368-978d-8c6cd7872bff.png">
After:
<img width="750" alt="after" src="https://user-images.githubusercontent.com/69750637/146467409-c47064fd-cbbb-4b48-b5b1-a915c80dd856.png">
