### PR TITLE
bug: fix typo in TSStringEscape (#81)

### DIFF
--- a/lua/nordic/colors/syntax.lua
+++ b/lua/nordic/colors/syntax.lua
@@ -174,7 +174,7 @@ return function(c, s, cs)
     local strings_specials = {
         -- TS
         'TSStringRegex',
-        'TSStriingEscape',
+        'TSStringEscape',
         'SpecialChar', -- VL
         'cSpecialCharacter', -- C/C++
         'pythonescape', -- python


### PR DESCRIPTION
Hope, now with the correct commit signature to pass the commit linter.
Will close (#81)