### PR TITLE
fix: Better hl for `LspReference...`

### DIFF
--- a/lua/nordic/colors/lsp.lua
+++ b/lua/nordic/colors/lsp.lua
@@ -1,8 +1,8 @@
 return function(c, s)
     return {
-        { 'LspReferenceText', c.dark_white },
-        { 'LspReferenceRead', c.white },
-        { 'LspReferenceWrite', c.bright_white },
+        { 'LspReferenceText', c.none, c.gray },
+        { 'LspReferenceRead', c.none, c.gray },
+        { 'LspReferenceWrite', c.none, c.gray },
         { 'LspDiagnosticsDefaultHint', c.intense_blue },
         { 'LspDiagnosticsDefaultError', c.red },
         { 'LspDiagnosticsDefaultWarning', c.yellow },


### PR DESCRIPTION
Change of `LspReference...` hl colors mentioned in #89. I used the same colors as in the original [nord-vim](https://github.com/arcticicestudio/nord-vim) colorscheme.

Here an example:
![lsp_reference_hl](https://user-images.githubusercontent.com/50531499/199944287-edc36079-d4c6-435d-8eca-7b6378e234c5.png)

I don't know why `var_b` is also highlighted. But the highlight is clearly distinguishable from the search results and also works on darker (blue) text.

---

Closes #89